### PR TITLE
Fix order of calloc parameters

### DIFF
--- a/components/calibration/calibration.c
+++ b/components/calibration/calibration.c
@@ -72,7 +72,7 @@ esp_err_t calibration_init(calibration_handle_t *handler, size_t count, calibrat
     handler->type = type;
     handler->count = count;
     handler->filled = 0;
-    handler->points = calloc(sizeof(calibration_point_t), handler->count);
+    handler->points = calloc(handler->count, sizeof(calibration_point_t));
     if (!handler->points)
     {
         ESP_LOGE(TAG, "Could not allocate memory for calibration points");


### PR DESCRIPTION
calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument.

earlier argument should specify number of elements, later size of each element

**IMPORTANT**: Please **do not create a Pull Request** without
[creating an issue](https://github.com/UncleRus/esp-idf-lib/issues/new/choose)
first.

Include `fixes` or other supported keywords that links a PR to an
issue in either a commit log or the PR. See
[Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
for the keywords.

Make sure your branch is up-to-date with the latest `master` branch. If it is
not, do `git rebase master`.

After creating a PR, make sure all the tests in the CI pass. If you cannot
understand why a test fails, ask for help.
